### PR TITLE
Fixes typo in basic example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ codec : Codec (List Int)
 codec =
     Codec.list Codec.int
 
-encode : List Int -> Json.Encode.Value
+encode : List Int -> Value
 encode list =
     Codec.encoder codec list
 


### PR DESCRIPTION
Value has been exposed by Codec, but `Json.Decode.Value` was used instead.