### PR TITLE
Small change in the Semaphore example

### DIFF
--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -471,8 +471,8 @@ You need to pass a pattern matching function, built like this:
 
     type Semaphore
         = Red Int String
-        | Yellow Float
-        | Green
+        | Yellow
+        | Green Float
 
     semaphoreCodec : Codec Semaphore
     semaphoreCodec =
@@ -480,17 +480,17 @@ You need to pass a pattern matching function, built like this:
             (\red yellow green value ->
                 case value of
                     Red i s ->
-                        red i s
+                        red i s 
 
-                    Yellow f ->
-                        yellow f
+                    Yellow ->
+                        yellow
 
-                    Green ->
-                        green
+                    Green f ->
+                        green f
             )
             |> Codec.variant2 "Red" Red Codec.int Codec.string
-            |> Codec.variant1 "Yellow" Yellow Codec.float
-            |> Codec.variant0 "Green" Green
+            |> Codec.variant0 "Yellow" Yellow
+            |> Codec.variant1 "Green" Green Codec.float
             |> Codec.buildCustom
 
 -}

--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -480,7 +480,7 @@ You need to pass a pattern matching function, built like this:
             (\red yellow green value ->
                 case value of
                     Red i s ->
-                        red i s 
+                        red i s
 
                     Yellow ->
                         yellow


### PR DESCRIPTION
(This is a small issue, feel free to discard this PR if it doesn't make sense to you)

Every time that I follow this example, I think that variants need to be in order:

* variant2
* variant1
* variant0

Only later I realize that the number is actualy the number of payload values to the type constructors. Is this only me?

So I changed the order to

* variant1
* variant2
* variant0

This hopefully would help everybody (or at least me) not to get confused