### PR TITLE
Add optional, optionalField and optionalFieldWithDefault codecs.

### DIFF
--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -456,7 +456,7 @@ optionalField name getter codec (ObjectCodec ocodec) =
                     Nothing ->
                         ocodec.encoder v
         , decoder =
-            validateNullableField name codec
+            validateOptionalField name codec
                 |> JD.map2 (\f x -> f x) ocodec.decoder
         }
 
@@ -468,14 +468,14 @@ optionalFieldWithDefault name getter codec default (ObjectCodec ocodec) =
     ObjectCodec
         { encoder = \v -> ( name, encoder codec <| getter v ) :: ocodec.encoder v
         , decoder =
-            validateNullableField name codec
+            validateOptionalField name codec
                 |> JD.andThen (Maybe.withDefault default >> JD.succeed)
                 |> JD.map2 (\f x -> f x) ocodec.decoder
         }
 
 
-validateNullableField : String -> Codec f -> Decoder (Maybe f)
-validateNullableField name codec =
+validateOptionalField : String -> Codec f -> Decoder (Maybe f)
+validateOptionalField name codec =
     JD.value
         |> JD.andThen
             (\json ->

--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -257,7 +257,7 @@ generate a decoding error, instead of silently failing and returning a `Nothing`
     optionalCodec = Codec.optional Codec.int
 
     Codec.decodeString optionalCodec "\"Not an int\""
-    --Returns a json decoding error with the message containing: "Expecting an INT"
+    -- Returns a json decoding error with the message containing: "Expecting an INT"
 
 -}
 optional : Codec a -> Codec (Maybe a)
@@ -462,18 +462,20 @@ nullableField name getter codec ocodec =
 {-| Similar to the `maybeField` codec, with added validation when the data exists. This means that bad data will
 generate a decoding error, instead of silently failing and returning a `Nothing`.
 
-1/ valid data provided: returns `Just` the decoded data
-2/ no data provided (either the field is missing, or it is null): returns `Nothing`
-3/ invalid data provided: returns a decoding error
+  - valid data provided: returns `Just` the decoded data
+  - no data provided (either the field is missing, or it is `null`): returns `Nothing`
+  - invalid data provided: returns a decoding error
 
-    type alias JustAnInt = { myInt: Maybe Int }
+```
+type alias JustAnInt = { myInt: Maybe Int }
 
-    objectCodec = Codec.object JustAnInt
+objectCodec = Codec.object JustAnInt
     |> Codec.optionalField "myInt" .myInt Codec.int
     |> Codec.buildObject
 
-    Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
-    --Returns a json decoding error with the message containing: "Expecting an INT"
+Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
+-- Returns a json decoding error with the message containing: "Expecting an INT"
+```
 
 -}
 optionalField : String -> (a -> Maybe f) -> Codec f -> ObjectCodec a (Maybe f -> b) -> ObjectCodec a b
@@ -496,24 +498,26 @@ optionalField name getter codec (ObjectCodec ocodec) =
 {-| Similar to the `optionalField` codec, but the default value is provided in case the data is missing.
 This means that bad data will generate a decoding error, instead of silently failing and returning the default value.
 
-1/ valid data provided: returns the decoded value
-2/ no data provided (either the field is missing, or it is null): returns the default value
-3/ invalid data provided: returns a decoding error
+  - valid data provided: returns the decoded value
+  - no data provided (either the field is missing, or it is `null`): returns the default value
+  - invalid data provided: returns a decoding error
 
-    type alias JustAnInt = { myInt: Int }
+```
+type alias JustAnInt = { myInt: Int }
 
-    objectCodec = Codec.object JustAnInt
+objectCodec = Codec.object JustAnInt
     |> Codec.optionalFieldWithDefault "myInt" .myInt Codec.int 0
     |> Codec.buildObject
 
-    Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
-    --Returns a json decoding error with the message containing: "Expecting an INT"
+Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
+-- Returns a json decoding error with the message containing: "Expecting an INT"
 
-    Codec.decodeString objectCodec """{"myInt": null}"""
-    --Returns: Ok { myInt = 0 }
+Codec.decodeString objectCodec """{"myInt": null}"""
+-- Returns: Ok { myInt = 0 }
 
-    Codec.decodeString objectCodec "{}"
-    --Returns: Ok { myInt = 0 }
+Codec.decodeString objectCodec "{}"
+-- Returns: Ok { myInt = 0 }
+```
 
 -}
 optionalFieldWithDefault : String -> (a -> f) -> Codec f -> f -> ObjectCodec a (f -> b) -> ObjectCodec a b

--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -254,10 +254,10 @@ maybe codec =
 {-| Similar to the `maybe` codec, with added validation when the data exists. This means that bad data will
 generate a decoding error, instead of silently failing and returning a `Nothing`.
 
-optionalCodec = Codec.optional Codec.int
+    optionalCodec = Codec.optional Codec.int
 
-Codec.decodeString optionalCodec "\"Not an int\""
---Returns a json decoding error with the message containing: "Expecting an INT"
+    Codec.decodeString optionalCodec "\"Not an int\""
+    --Returns a json decoding error with the message containing: "Expecting an INT"
 
 -}
 optional : Codec a -> Codec (Maybe a)
@@ -462,18 +462,18 @@ nullableField name getter codec ocodec =
 {-| Similar to the `maybeField` codec, with added validation when the data exists. This means that bad data will
 generate a decoding error, instead of silently failing and returning a `Nothing`.
 
-- valid data provided: returns `Just` the decoded data
-- no data provided (either the field is missing, or it is null): returns `Nothing`
-- invalid data provided: returns a decoding error
+1/ valid data provided: returns `Just` the decoded data
+2/ no data provided (either the field is missing, or it is null): returns `Nothing`
+3/ invalid data provided: returns a decoding error
 
-type alias JustAnInt = { myInt: Maybe Int }
+    type alias JustAnInt = { myInt: Maybe Int }
 
-objectCodec = Codec.object JustAnInt
+    objectCodec = Codec.object JustAnInt
     |> Codec.optionalField "myInt" .myInt Codec.int
     |> Codec.buildObject
 
-Codec.decodeString objectCodec "{\"myInt\": \"Not an int\"}"
---Returns a json decoding error with the message containing: "Expecting an INT"
+    Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
+    --Returns a json decoding error with the message containing: "Expecting an INT"
 
 -}
 optionalField : String -> (a -> Maybe f) -> Codec f -> ObjectCodec a (Maybe f -> b) -> ObjectCodec a b
@@ -496,24 +496,24 @@ optionalField name getter codec (ObjectCodec ocodec) =
 {-| Similar to the `optionalField` codec, but the default value is provided in case the data is missing.
 This means that bad data will generate a decoding error, instead of silently failing and returning the default value.
 
-- valid data provided: returns the decoded value
-- no data provided (either the field is missing, or it is null): returns the default value
-- invalid data provided: returns a decoding error
+1/ valid data provided: returns the decoded value
+2/ no data provided (either the field is missing, or it is null): returns the default value
+3/ invalid data provided: returns a decoding error
 
-type alias JustAnInt = { myInt: Int }
+    type alias JustAnInt = { myInt: Int }
 
-objectCodec = Codec.object JustAnInt
+    objectCodec = Codec.object JustAnInt
     |> Codec.optionalFieldWithDefault "myInt" .myInt Codec.int 0
     |> Codec.buildObject
 
-Codec.decodeString objectCodec "{\"myInt\": \"Not an int\"}"
---Returns a json decoding error with the message containing: "Expecting an INT"
+    Codec.decodeString objectCodec """{"myInt": "Not an int"}"""
+    --Returns a json decoding error with the message containing: "Expecting an INT"
 
-Codec.decodeString objectCodec "{\"myInt\": null}"
---Returns: Ok { myInt = 0 }
+    Codec.decodeString objectCodec """{"myInt": null}"""
+    --Returns: Ok { myInt = 0 }
 
-Codec.decodeString objectCodec "{}"
---Returns: Ok { myInt = 0 }
+    Codec.decodeString objectCodec "{}"
+    --Returns: Ok { myInt = 0 }
 
 -}
 optionalFieldWithDefault : String -> (a -> f) -> Codec f -> f -> ObjectCodec a (f -> b) -> ObjectCodec a b

--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -466,7 +466,7 @@ optionalField name getter codec (ObjectCodec ocodec) =
                     Nothing ->
                         ocodec.encoder v
         , decoder =
-            validateOptionalField name codec
+            decodeOptionalField name codec
                 |> JD.map2 (\f x -> f x) ocodec.decoder
         }
 
@@ -478,14 +478,14 @@ optionalFieldWithDefault name getter codec default (ObjectCodec ocodec) =
     ObjectCodec
         { encoder = \v -> ( name, encoder codec <| getter v ) :: ocodec.encoder v
         , decoder =
-            validateOptionalField name codec
+            decodeOptionalField name codec
                 |> JD.andThen (Maybe.withDefault default >> JD.succeed)
                 |> JD.map2 (\f x -> f x) ocodec.decoder
         }
 
 
-validateOptionalField : String -> Codec f -> Decoder (Maybe f)
-validateOptionalField name codec =
+decodeOptionalField : String -> Codec f -> Decoder (Maybe f)
+decodeOptionalField name codec =
     JD.value
         |> JD.andThen
             (\json ->

--- a/src/Codec.elm
+++ b/src/Codec.elm
@@ -256,27 +256,8 @@ maybe codec =
 optional : Codec a -> Codec (Maybe a)
 optional codec =
     Codec
-        { decoder =
-            JD.value
-                |> JD.andThen
-                    (\json ->
-                        case JD.decodeValue JD.value json of
-                            Ok _ ->
-                                -- The field is present, so run the decoder on it.
-                                JD.nullable (decoder codec)
-
-                            Err _ ->
-                                -- The field was missing, which is fine!
-                                JD.succeed Nothing
-                    )
-        , encoder =
-            \v ->
-                case v of
-                    Nothing ->
-                        JE.null
-
-                    Just x ->
-                        encoder codec x
+        { decoder = JD.nullable (decoder codec)
+        , encoder = encoder (maybe codec)
         }
 
 

--- a/tests/Base.elm
+++ b/tests/Base.elm
@@ -18,6 +18,7 @@ suite =
         , describe "Custom" customTests
         , describe "bimap" bimapTests
         , describe "maybe" maybeTests
+        , describe "optional" optionalTests
         , describe "succeed"
             [ test "roundtrips"
                 (\_ ->
@@ -339,6 +340,48 @@ maybeTests =
                   Codec.maybe Codec.int
           ]
     -}
+    ]
+
+
+optionalTests : List Test
+optionalTests =
+    let
+        testCodec =
+            Codec.optional Codec.int
+    in
+    [ test "should accept a provided value" <|
+        \_ ->
+            "42"
+                |> Codec.decodeString testCodec
+                |> Expect.equal (Ok (Just 42))
+    , test "should resolve to Nothing when null is provided" <|
+        \_ ->
+            "null"
+                |> Codec.decodeString testCodec
+                |> Expect.equal (Ok Nothing)
+    , test "should fail when provided value is invalid" <|
+        \_ ->
+            "[]"
+                |> Codec.decodeString testCodec
+                |> Result.mapError JD.errorToString
+                |> (\res ->
+                        case res of
+                            Ok _ ->
+                                Expect.fail "Shouldn't have succeeded"
+
+                            Err msg ->
+                                Expect.true "Expected error message found" (String.contains "Expecting an INT" msg)
+                   )
+    , test "should encode available data" <|
+        \_ ->
+            Just 1
+                |> Codec.encodeToString 0 testCodec
+                |> Expect.equal "1"
+    , test "should encode missing data" <|
+        \_ ->
+            Nothing
+                |> Codec.encodeToString 0 testCodec
+                |> Expect.equal "null"
     ]
 
 


### PR DESCRIPTION
This tries to address #14 by introducing new `optional`, `optionalField` and `optionalFieldWithDefault` codecs, which would basically provide a similar implementation as what Json.Decode.Extra's [`optionalNullableField`](https://package.elm-lang.org/packages/elm-community/json-extra/latest/Json-Decode-Extra#optionalNullableField) does.

Shipping this patch would only require bumping a minor version, as it only adds 3 new functions, and so would stay backward compatible.

What do you think?